### PR TITLE
should serve .d.mts and .d.cts files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": true
+}

--- a/accessControl/permissions.gadget.ts
+++ b/accessControl/permissions.gadget.ts
@@ -18,11 +18,6 @@ export const permissions: GadgetPermissions = {
       models: {
         cache: {
           read: true,
-          actions: {
-            create: true,
-            delete: true,
-            update: true,
-          },
         },
       },
     },

--- a/api/models/session/schema.gadget.ts
+++ b/api/models/session/schema.gadget.ts
@@ -10,7 +10,8 @@ export const schema: GadgetModel = {
     roles: {
       type: "roleList",
       default: ["Unauthenticated"],
-      storageKey: "ModelField-w8yNr8ZptOSU::FieldStorageEpoch-6PzaZxHSIl2a",
+      storageKey:
+        "ModelField-w8yNr8ZptOSU::FieldStorageEpoch-6PzaZxHSIl2a",
     },
   },
 };

--- a/api/services/TypesArtifactBuilder.ts
+++ b/api/services/TypesArtifactBuilder.ts
@@ -79,7 +79,9 @@ export class TypesArtifactBuilder {
           if (
             path.basename(fileName) == "package.json" ||
             fileName.endsWith(".d.ts") ||
-            (packagesThatNeedAllTsFiles.has(currentPackageName) && fileName.endsWith(".ts"))
+            fileName.endsWith(".d.mts") ||
+            fileName.endsWith(".d.cts") ||
+            (packagesThatNeedAllTsFiles.has(currentPackageName) && (fileName.endsWith(".ts") || fileName.endsWith(".mts") || fileName.endsWith(".cts")))
           ) {
             files[fileName] = await getStream(stream);
           } else if (fileName.endsWith(".json")) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@fastify/cors": "^9.0.1",
     "@gadget-client/typescript-type-cdn": "link:.gadget/client",
-    "@gadgetinc/react": "^0.18.2",
+    "@gadgetinc/react": "^0.18.3",
     "@sentry/node": "^7.17.3",
     "@types/gunzip-maybe": "^1.4.0",
     "@types/react": "^18.0.28",

--- a/test/TypesArtifactBuilder.spec.ts
+++ b/test/TypesArtifactBuilder.spec.ts
@@ -42,6 +42,15 @@ describe("TypesArtifactBuilder", () => {
     expect(dtsFiles.length).toBeGreaterThan(0);
   }, 30000);
 
+  it("should extract .d.mts files from a package", async () => {
+    const builder = new TypesArtifactBuilder("openai", "4.22.0");
+    const result = await builder.buildTypes();
+
+    const dMtsFiles = Object.keys(result).filter((file) => file.endsWith(".d.mts"));
+    console.log(dMtsFiles);
+    expect(dMtsFiles.length).toBeGreaterThan(0);
+  }, 30000);
+
   it("should handle packages that need all TS files", async () => {
     const builder = new TypesArtifactBuilder("@shopify/app-bridge-types", "0.0.1");
     const result = await builder.buildTypes();

--- a/yarn.lock
+++ b/yarn.lock
@@ -174,10 +174,10 @@
   version "0.0.0"
   uid ""
 
-"@gadgetinc/api-client-core@0.15.34", "@gadgetinc/api-client-core@^0.15.34":
-  version "0.15.34"
-  resolved "https://registry.yarnpkg.com/@gadgetinc/api-client-core/-/api-client-core-0.15.34.tgz#30d5a9ee423832dfae852f6aad4f813391cbd11f"
-  integrity sha512-Z7S+JprURJ2Y0XDySp5bMMM0ctBmZOs6ezPPY4+amV5Ba1e2J9y5JbPIGrBxksysj5LydwZyntNTplVOJVVzwg==
+"@gadgetinc/api-client-core@0.15.35", "@gadgetinc/api-client-core@^0.15.35":
+  version "0.15.35"
+  resolved "https://registry.yarnpkg.com/@gadgetinc/api-client-core/-/api-client-core-0.15.35.tgz#40b3cb4fb2d132144c6ca1dbd5b536552cf2ce53"
+  integrity sha512-DlNnY2ghQJP3qt2PsUN5ii3sQC8i1Fl9N5aTpOZd5uiHRbZci5u4SXhYqFnLSfYV2Ym2vhen5YmWd3Cl/QOYCQ==
   dependencies:
     "@0no-co/graphql.web" "^1.0.4"
     "@n1ru4l/graphql-live-query" "^0.10.0"
@@ -202,13 +202,13 @@
   dependencies:
     prettier-plugin-organize-imports "^3.2.1"
 
-"@gadgetinc/react@^0.18.2":
-  version "0.18.2"
-  resolved "https://registry.yarnpkg.com/@gadgetinc/react/-/react-0.18.2.tgz#dc838379e7e26b81d60d1723249e01064db8dc03"
-  integrity sha512-2K2znXPF2ytRL563TBoGGLGmw7PVbWZwE1GiM5VhNKoj8P2V482auuCpwYAWcxLLo++WNabt34BG7FHSjus1gQ==
+"@gadgetinc/react@^0.18.3":
+  version "0.18.3"
+  resolved "https://registry.yarnpkg.com/@gadgetinc/react/-/react-0.18.3.tgz#26e7c7edfa2a758c348ac0da7045b718b83bcba6"
+  integrity sha512-VxMBVwjwJXYy6vJNMp3zvww1WEWTm20RFRJhlyR866GFk0vqfbTs4G5/QLEeA1EGz6jqUCk3Ft+IurJc68oCqw==
   dependencies:
     "@0no-co/graphql.web" "^1.0.4"
-    "@gadgetinc/api-client-core" "^0.15.34"
+    "@gadgetinc/api-client-core" "^0.15.35"
     "@hookform/resolvers" "^3.3.1"
     filesize "^10.1.2"
     pluralize "^8.0.0"
@@ -500,6 +500,13 @@
   version "20.17.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.17.6.tgz#6e4073230c180d3579e8c60141f99efdf5df0081"
   integrity sha512-VEI7OdvK2wP7XHnsuXbAJnEpEkF6NjSN45QJlL4VGqZSXsnicpesdTWsg9RISeSdYd3yeRj/y3k5KGjUXYnFwQ==
+  dependencies:
+    undici-types "~6.19.2"
+
+"@types/node@^20.17.7":
+  version "20.17.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.17.8.tgz#42748cdb169adf5be7c9760604c72820c7b7d560"
+  integrity sha512-ahz2g6/oqbKalW9sPv6L2iRbhLnojxjYWspAqhjvqSWBgGebEJT5GvRmk0QXPj3sbC6rU0GTQjPLQkmR8CObvA==
   dependencies:
     undici-types "~6.19.2"
 


### PR DESCRIPTION
the openai package uses an `index.d.mts` file in its `exports` which the types cdn doesn't currently serve; this fixes that